### PR TITLE
feat: add pdftotext api endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.20 AS build
+
+WORKDIR /usr/src/app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+COPY *.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /usr/local/bin/app ./...
+
+FROM alpine:3.18
+RUN apk add --no-cache poppler-utils
+COPY --from=build /usr/local/bin/app /usr/bin/
+
+EXPOSE 8080
+
+CMD ["app"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cemdorst/pdftotext-api
+
+go 1.19

--- a/main.go
+++ b/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+func pdftotextHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the request body to get the PDF file content.
+	file, _, err := r.FormFile("pdf")
+	if err != nil {
+		http.Error(w, "Failed to parse PDF file from request", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// Create a temporary file to save the uploaded PDF.
+	tmpFile, err := ioutil.TempFile("", "input_*.pdf")
+	if err != nil {
+		http.Error(w, "Failed to create temporary file", http.StatusInternalServerError)
+		return
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Save the PDF content to the temporary file.
+	_, err = io.Copy(tmpFile, file)
+	if err != nil {
+		http.Error(w, "Failed to save PDF content to temporary file", http.StatusInternalServerError)
+		return
+	}
+
+	// Execute pdftotext command.
+	cmd := exec.Command("pdftotext", tmpFile.Name(), "-")
+	output, err := cmd.Output()
+	if err != nil {
+		http.Error(w, "Failed to convert PDF to text", http.StatusInternalServerError)
+		return
+	}
+
+	// Set response content type to plain text.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	// Write the PDF text to the response.
+	_, err = w.Write(output)
+	if err != nil {
+		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		return
+	}
+}
+
+func main() {
+	// Register the /pdftotxt endpoint to the pdftotextHandler function.
+	http.HandleFunc("/pdftotxt", pdftotextHandler)
+
+	// Start the server on port 8080.
+	fmt.Println("Server listening on port 8080")
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		fmt.Printf("Failed to start server: %v\n", err)
+	}
+}


### PR DESCRIPTION
Pdftotext microservice:
  - listens on localhost:8080

Example:
 - `curl -X POST -F "pdf=@your_file.pdf" http://localhost:8080/pdftotxt`